### PR TITLE
[#7] fix: Improve "phpcs fix" command without custom ruleset

### DIFF
--- a/commands/web/phpcs
+++ b/commands/web/phpcs
@@ -36,14 +36,21 @@ if [[ $FIX == "fix" ]]; then
   COMMAND="phpcbf"
 fi
 
-if [ -f "web/modules/contrib/$MODULE_NAME/phpcs.xml" ]; then
-  "vendor/bin/$COMMAND" \
+if ! command -v $COMMAND >/dev/null; then
+  echo "$COMMAND is not available. You may need to 'ddev composer install'"
+  exit 1
+fi
+
+if [ -f "$DDEV_DOCROOT/modules/contrib/$MODULE_NAME/phpcs.xml.dist" ]; then
+  echo "Using custom PHPCS ruleset for module '$MODULE_NAME'."
+  $COMMAND \
     -s \
-    --standard=web/modules/contrib/$MODULE_NAME/phpcs.xml \
-    --basepath=web/modules/contrib/$MODULE_NAME \
+    --standard=$DDEV_DOCROOT/modules/contrib/$MODULE_NAME/phpcs.xml.dist \
+    --basepath=$DDEV_DOCROOT/modules/contrib/$MODULE_NAME \
     --report-full --report-summary --report-source \
-    web/modules/contrib/$MODULE_NAME
+    $DDEV_DOCROOT/modules/contrib/$MODULE_NAME
 else
-    curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
-    phpcs -s --report-full --report-summary --report-source web/modules/contrib/$MODULE_NAME
+  echo "Using default PHPCS ruleset."
+  curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
+  $COMMAND -s --report-full --report-summary --report-source $DDEV_DOCROOT/modules/contrib/$MODULE_NAME
 fi


### PR DESCRIPTION
## The Issue

- Fixes #7

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/lussoluca/ddev-drupal-suite/tarball/refs/pull/8/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
